### PR TITLE
#32 Fix for log retention

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,3 +1,15 @@
+resource "aws_cloudwatch_log_group" "cloudinitlog" {
+  count             = var.vault_enable_cloudwatch ? 1 : 0
+  name              = "${var.vault_name}-cloudinitlog"
+  retention_in_days = 7
+}
+
+resource "aws_cloudwatch_log_group" "vaultlog" {
+  count             = var.vault_enable_cloudwatch ? 1 : 0
+  name              = "${var.vault_name}-vaultlog"
+  retention_in_days = 7
+}
+
 resource "aws_cloudwatch_dashboard" "default" {
   count          = var.vault_enable_cloudwatch ? 1 : 0
   dashboard_body = <<EOF

--- a/scripts/cloudwatch.sh
+++ b/scripts/cloudwatch.sh
@@ -102,13 +102,11 @@ cat << EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
             "file_path": "/var/log/cloud-init-output.log",
             "log_group_name": "${vault_name}-cloudinitlog",
             "log_stream_name": "${instance_id}",
-            "retention_in_days": 7
           },
           {
             "file_path": "/var/log/vault/vault.log",
             "log_group_name": "${vault_name}-vaultlog",
             "log_stream_name": "${instance_id}",
-            "retention_in_days": 7
           }
         ]
       }

--- a/scripts/cloudwatch.sh
+++ b/scripts/cloudwatch.sh
@@ -102,11 +102,13 @@ cat << EOF > /opt/aws/amazon-cloudwatch-agent/bin/config.json
             "file_path": "/var/log/cloud-init-output.log",
             "log_group_name": "${vault_name}-cloudinitlog",
             "log_stream_name": "${instance_id}",
+            "retention_in_days": 7
           },
           {
             "file_path": "/var/log/vault/vault.log",
             "log_group_name": "${vault_name}-vaultlog",
             "log_stream_name": "${instance_id}",
+            "retention_in_days": 7
           }
         ]
       }


### PR DESCRIPTION
#32 
There was an issue where the logs retention would be set to NEVER EXPIRE while the config during provisioning set it to 7 days.

Also the Cloudwatch log groups are now TF managed, where as they were automatically created before. When logs are pushed by the agent to a non-existing log group, log groups are automatically created. This ment that a terraform destroy would not clean them up AND they would be created with "default" settings.

Retention is now configured in the TF resource block AND the cloudwatch agent install script.

Why configure retention of logs twice?
[AWS docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html):"If you specify retention_in_days for the same log group in multiple places, the retention is set if all of those values are equal. However, if different retention_in_days values are specified for the same log group in multiple places, the log retention will not be set and the agent will stop, returning an error."